### PR TITLE
Modified VisionIOPhotonVision 

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -69,6 +69,10 @@ public class VisionConstants {
         1.0 // Camera 1
       };
 
+  // Maximum reads per robot periodic loop
+  // (This ensures we dont loop override while processing tags)
+  public static int MAX_READS_PER_ITERATION = 5;
+
   public static final Pose2d[] centerFaces =
       new Pose2d[] {
         aprilTagLayout.getTagPose(6).get().toPose2d(),

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOPhotonVision.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOPhotonVision.java
@@ -57,6 +57,9 @@ public class VisionIOPhotonVision implements VisionIO {
     //   Logger.recordOutput("Ton of camera results flag", true);
     // }
 
+    int unReadResultsSize = allUnreadResults.size();
+    int numResultsRead = 0;
+
     for (var result : allUnreadResults) {
       // Update latest target observation
       if (result.hasTargets()) {
@@ -135,6 +138,16 @@ public class VisionIOPhotonVision implements VisionIO {
                   cameraToTarget.getTranslation().getNorm(), // Average tag distance
                   PoseObservationType.PHOTONVISION)); // Observation type
         }
+      }
+
+      numResultsRead++;
+      if (numResultsRead > MAX_READS_PER_ITERATION) {
+        System.err.println(
+            "WARN: Did not process allUnreadResults: numResultsRead = "
+                + numResultsRead
+                + "/"
+                + unReadResultsSize);
+        break;
       }
     }
 


### PR DESCRIPTION
Modification to VisionIOPhotonVision to limit the number of read result. This ensures if something went wrong and there were many unread results we can process at least some of them and not cause a loop overrun. How many is determined by MAX_READS_PER_ITERATION. Unfortunately we loose any of the data because calling `camera.getAllUnreadResults()` clears the FIFO queue. 

A future approach might read all the unread results and process them in a separate lower priority thread. Something like how our Odometry thread processes result asynchronously from the robot loop thread. 